### PR TITLE
fix(rxformmappermodule): prevent multiple import

### DIFF
--- a/projects/rx-form-mapper/src/lib/rx-form-mapper.module.ts
+++ b/projects/rx-form-mapper/src/lib/rx-form-mapper.module.ts
@@ -1,13 +1,24 @@
-import { NgModule } from '@angular/core';
-import { CustomMapperResolver } from './services/custom-mapper-resolver';
-import { RxFormMapper } from './services/rx-form-mapper.service';
-import { ValidatorResolver } from './services/validator-resolver';
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { RxFormMapper, ValidatorResolver, CustomMapperResolver } from './services';
 
-@NgModule({
-	providers: [
-		RxFormMapper,
-		CustomMapperResolver,
-		ValidatorResolver
-	]
-})
-export class RxFormMapperModule {}
+@NgModule()
+export class RxFormMapperModule {
+
+	public static forRoot(): ModuleWithProviders<RxFormMapperModule> {
+		return {
+			ngModule: RxFormMapperModule,
+			providers: [
+				RxFormMapper,
+				CustomMapperResolver,
+				ValidatorResolver
+			]
+		};
+	}
+
+	public constructor(@Optional() @SkipSelf() parentModule?: RxFormMapperModule) {
+		if (parentModule) {
+			throw new Error('RxFormMapperModule is already loaded. Import it in the AppModule only');
+		}
+	}
+
+}

--- a/projects/rx-form-mapper/src/lib/tests/custom-mapper-resolver.spec.ts
+++ b/projects/rx-form-mapper/src/lib/tests/custom-mapper-resolver.spec.ts
@@ -30,10 +30,10 @@ class InstantiableCustomControlMapper extends UninstantiableCustomControlMapper 
 	}
 }
 
-describe('RxFormMapper', () => {
+describe('CustomMapperResolver', () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [RxFormMapperModule],
+			imports: [RxFormMapperModule.forRoot()],
 		}).compileComponents();
 	});
 

--- a/projects/rx-form-mapper/src/lib/tests/rx-form-mapper-module.spec.ts
+++ b/projects/rx-form-mapper/src/lib/tests/rx-form-mapper-module.spec.ts
@@ -1,0 +1,46 @@
+import { Component, NgModule, NgModuleFactoryLoader } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router, RouterModule } from '@angular/router';
+import { RxFormMapperModule } from '..';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('RxFormMapperModule', () => {
+
+	@Component({ template: '' })
+	class TestComponent { }
+
+	@NgModule({
+		imports: [RxFormMapperModule.forRoot(), RouterModule.forChild([{ path: '', component: TestComponent }])]
+	})
+	class ChildModule { }
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [RxFormMapperModule.forRoot(), RouterTestingModule.withRoutes([{ path: '', loadChildren: './test/ChildModule#ChildModule' }])],
+		}).compileComponents();
+
+
+	});
+
+	it('Should not provide twice', async () => {
+		// tslint:disable-next-line: deprecation
+		const loader: any = TestBed.inject(NgModuleFactoryLoader);
+		const router = TestBed.inject(Router);
+
+		loader.stubbedModules = {
+			'./test/ChildModule#ChildModule': ChildModule,
+		};
+
+		let error: Error = null;
+
+		try {
+			await router.navigate([]);
+		} catch (e) {
+			error = e;
+		}
+
+		expect(error.message).toEqual('RxFormMapperModule is already loaded. Import it in the AppModule only');
+	});
+
+});
+

--- a/projects/rx-form-mapper/src/lib/tests/rx-form-mapper.spec.ts
+++ b/projects/rx-form-mapper/src/lib/tests/rx-form-mapper.spec.ts
@@ -11,10 +11,10 @@ import {
 } from '@angular/forms';
 import { of } from 'rxjs';
 
-describe('CustomMapperResolver', () => {
+describe('RxFormMapper', () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [RxFormMapperModule]
+			imports: [RxFormMapperModule.forRoot()]
 		}).compileComponents();
 	});
 

--- a/projects/rx-form-mapper/src/lib/tests/validator-resolver.spec.ts
+++ b/projects/rx-form-mapper/src/lib/tests/validator-resolver.spec.ts
@@ -6,10 +6,10 @@ import { CustomControlMapper } from '../interfaces';
 import { RxFormMapper, ValidatorResolver } from '../services';
 import { CustomMapperResolver } from '../services/custom-mapper-resolver';
 
-describe('RxFormMapper', () => {
+describe('ValidatorResolver', () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [RxFormMapperModule],
+			imports: [RxFormMapperModule.forRoot()],
 		}).compileComponents();
 	});
 


### PR DESCRIPTION
use forRoot pattern to prevent multiple import

BREAKING CHANGE: simple module import no longer supports

#101